### PR TITLE
Add a personalize section for naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,25 @@
             </div>
             <p class="input-hint">Tip: Be short and descriptive (occasion, recipient, tone). Press Enter to generate.</p>
         </div>
+
+        <!-- Personalization -->
+        <section class="personalize-section" aria-labelledby="personalize-heading">
+            <h3 id="personalize-heading">Personalize</h3>
+
+            <label for="recipient-name">Recipient name</label>
+            <div class="personalize-row">
+                <input type="text" id="recipient-name" placeholder="e.g., Alex" inputmode="text" />
+                <button id="apply-placeholders" type="button" aria-label="Apply personalization to message">Apply</button>
+            </div>
+
+            <!-- Added: Sender name (for {sender_name}) -->
+            <label for="sender-name">Sender name</label>
+            <div class="personalize-row">
+                <input type="text" id="sender-name" placeholder="e.g., John" inputmode="text" />
+            </div>
+
+            <small class="number-help">This replaces {name} and {sender_name} in the generated message</small>
+        </section>
         
         <!-- Output Section (Hidden until a message is generated) -->
         <div class="output-section" id="output-section" style="display: none;">

--- a/script.js
+++ b/script.js
@@ -90,6 +90,21 @@ const whatsappBtn = document.getElementById('whatsapp-btn');
 const whatsappNumber = document.getElementById('whatsapp-number');
 const themeToggle = document.getElementById('theme-toggle');
 
+// --- Personalization: DOM + state + helper ---
+const recipientName = document.getElementById('recipient-name');
+const senderName = document.getElementById('sender-name'); // NEW: sender name input
+const applyPlaceholdersBtn = document.getElementById('apply-placeholders');
+
+let currentTemplateRaw = null;   // stores the last chosen template
+let isManuallyEdited = false;    // prevents silent overwrite of user edits
+
+function applyPlaceholders(template, data) {
+  if (!template) return '';
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    const v = data[key];
+    return (v !== undefined && v !== null && String(v).trim() !== '') ? String(v) : `{${key}}`;
+  });
+}
 // Bot messaging DOM elements
 const enableBotMode = document.getElementById('enable-bot-mode');
 const botConfigOptions = document.getElementById('bot-config-options');
@@ -163,9 +178,19 @@ function generateMessage() {
     
     // Show the output section
     outputSection.style.display = 'block';
-    messageDisplay.textContent = randomTemplate;
-    editableMessage.value = randomTemplate;
-    
+
+    // Remember raw template and apply personalization
+    currentTemplateRaw = randomTemplate;
+    isManuallyEdited = false;
+
+    const filled = applyPlaceholders(currentTemplateRaw, {
+      name: recipientName ? recipientName.value.trim() : '',
+      sender_name: senderName ? senderName.value.trim() : ''
+    });
+
+    messageDisplay.textContent = filled;
+    editableMessage.value = filled;
+        
     // Scroll to output section
     outputSection.scrollIntoView({ behavior: 'smooth' });
     
@@ -237,6 +262,29 @@ async function copyMessage() {
 // Function to update message display when editing
 editableMessage.addEventListener('input', function() {
     messageDisplay.textContent = this.value;
+    isManuallyEdited = true; // personalization won't auto-overwrite your edits
+});
+
+applyPlaceholdersBtn && applyPlaceholdersBtn.addEventListener('click', function () {
+  if (!currentTemplateRaw) {
+    alert('Please generate a message first.');
+    return;
+  }
+
+  // Ask before overwriting if user edited the text
+  if (isManuallyEdited) {
+    const ok = confirm('You edited the message. Applying personalization will overwrite those edits. Continue?');
+    if (!ok) return;
+    isManuallyEdited = false;
+  }
+
+  const filled = applyPlaceholders(currentTemplateRaw, {
+    name: recipientName ? recipientName.value.trim() : '',
+    sender_name: senderName ? senderName.value.trim() : ''
+  });
+
+  messageDisplay.textContent = filled;
+  editableMessage.value = filled;
 });
 
 // Phone number validation function
@@ -1007,5 +1055,3 @@ function checkScheduledMessages() {
 
 // Export functions for global use
 window.fillPrompt = fillPrompt;
-
-

--- a/styles.css
+++ b/styles.css
@@ -167,6 +167,36 @@ input[type="text"]:focus {
     box-shadow: 0 0 0 6px var(--primary-glow);
 }
 
+/* Personalization section */
+.personalize-section {
+  margin: 20px 0;
+  padding: 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.personalize-section h3 {
+  color: var(--text);
+  margin-bottom: 10px;
+}
+
+.personalize-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.personalize-row input[type="text"] {
+  flex: 1 1 auto;
+  margin-bottom: 0;
+}
+
+#apply-placeholders {
+  flex: 0 0 auto;
+  padding: 10px 16px;
+}
+
 /* Make the input in the prompt-row take remaining space and keep button fixed */
 .prompt-card {
     display: flex;


### PR DESCRIPTION
Title: feat: personalize messages with recipient and sender names

## Summary
Add simple personalization for {name} and {sender_name} in generated messages with a minimal UI and small JS helper.

## Changes
- Added inputs: `#recipient-name`, `#sender-name` and `#apply-placeholders` button.
- On Generate, apply `{name}` and `{sender_name}` if provided.
- “Apply” re-applies personalization to the latest template (confirms before overwriting manual edits).

## How to test
- Enter a prompt → Generate.
- Fill “Recipient name” and “Sender name” → click “Apply”.
- Verify placeholders `{name}` and `{sender_name}` are replaced in both preview and textarea.

## Checklist
- [x] Only personalization logic/UI touched
- [x] Works with existing WhatsApp send flow
- [x] No console errors

<img width="1029" height="572" alt="image" src="https://github.com/user-attachments/assets/06388857-40bb-4743-b844-ef4422c86883" />
